### PR TITLE
Aesthetic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,18 +139,26 @@ near-indexer -config path/to/config.json -cmd=server
 
 | Method | Path                            | Description
 |--------|---------------------------------|------------------------------------
+| GET    | /                               | See all available endpoints
 | GET    | /health                         | Healthcheck endpoint
 | GET    | /status                         | App version info and sync status
 | GET    | /height                         | Current indexed blockchain height
+| GET    | /block                          | Get latest block
 | GET    | /blocks                         | Blocks search
 | GET    | /blocks/:hash                   | Block details by ID or Hash
-| GET    | /block_times                    | Block times stats
+| GET    | /block_stats                    | Block times stats for a time bucket
+| GET    | /block_times                    | Block average times
 | GET    | /block_times_interval           | Block creation stats
+| GET    | /epochs                         | Get list of epochs
+| GET    | /epochs/:id                     | Epoch details by ID
 | GET    | /validators                     | List of chain validators
-| GET    | /validator_times_interval       | Active validator stats
-| GET    | /accounts/:id                   | Account details by ID or Key
+| GET    | /validators/:id/epochs          | Validator Epochs performance by ID
+| GET    | /validators/:id/events          | Validator Events by ID
 | GET    | /transactions                   | List of transactions
-| GET    | /transactions/:hash             | Find transaction by hash
+| GET    | /transactions/:id               | Get transaction details
+| GET    | /accounts/:id                   | Account details by ID or Key
+| GET    | /delegations/:id                | Account delegations by ID
+| GET    | /events                         | List of Events
 
 ## License
 

--- a/server/server.go
+++ b/server/server.go
@@ -86,7 +86,7 @@ func (s Server) GetEndpoints(c *gin.Context) {
 			"/validators/:id/events": "Get validator events",
 			"/transactions":          "List all recent transactions",
 			"/transactions/:id":      "Get transaction details",
-			"/accounts/:id":          "Get accoun details",
+			"/accounts/:id":          "Get account details",
 			"/delegations/:id":       "Get account delegations",
 			"/events":                "Get list of events",
 		},


### PR DESCRIPTION
Just added some updates to the readme indexer endpoints to match the current available endpoints, removed one that no longer exists and fixes a typo in the `/` endpoint for `Get Accoun Details` to `Get Account Details`