### PR TITLE
Allow searching transactions by account (sender or receiver)

### DIFF
--- a/store/transactions.go
+++ b/store/transactions.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"time"
 
 	"github.com/figment-networks/indexing-engine/store/bulk"
@@ -71,12 +72,19 @@ func (s TransactionsStore) Search(search TransactionsSearch) (*PaginatedResult, 
 	if search.BlockHeight > 0 {
 		scope = scope.Where("height = ?", search.BlockHeight)
 	}
-	if search.Sender != "" {
-		scope = scope.Where("sender = ?", search.Sender)
+
+	if search.Account != "" {
+		accounts := strings.Split(search.Account, ",")
+		scope = scope.Where("sender IN (?) OR receiver IN (?)", accounts, accounts)
+	} else {
+		if search.Sender != "" {
+			scope = scope.Where("sender = ?", search.Sender)
+		}
+		if search.Receiver != "" {
+			scope = scope.Where("receiver = ?", search.Receiver)
+		}
 	}
-	if search.Receiver != "" {
-		scope = scope.Where("receiver = ?", search.Receiver)
-	}
+
 	if search.startTime != nil {
 		scope = scope.Where("time >= ?", search.startTime)
 	}

--- a/store/transactions_search.go
+++ b/store/transactions_search.go
@@ -17,6 +17,7 @@ type TransactionsSearch struct {
 	BlockHeight uint64 `form:"block_height"`
 	Sender      string `form:"sender"`
 	Receiver    string `form:"receiver"`
+	Account     string `form:"account"`
 	StartDate   string `form:"start_date"`
 	EndDate     string `form:"end_date"`
 


### PR DESCRIPTION
Possible use cases:

- Filter by sender: `sender=foo.near`
- Filter by receiver: `receiver=foo.near`
- Filter by account: `account=foo.near` 
- Filter by multiple accounts: `account=foo.near,bar.near`